### PR TITLE
fix get_env.py in case etcd are not on masters

### DIFF
--- a/backup/etcd/backup_etcd.sh
+++ b/backup/etcd/backup_etcd.sh
@@ -1,22 +1,16 @@
 #!/bin/sh
 set -e
 
-ORIG=$(cd $(dirname $0); pwd)
-
 # env variables you may want to change
 BACKUPDIR=${BACKUPDIR:-"/opt/backup/etcd"}
-MASTER_CONF=${MASTER_CONF:-"/etc/origin/master"}
-
-eval $(${ORIG}/get_env.py "${MASTER_CONF}")
-ETCD="etcdctl --cert-file ${etcd_certFile} --key-file ${etcd_keyFile} --ca-file ${etcd_ca} --no-sync --peers ${etcd_url}"
-
-$ETCD ls --recursive
 
 hotdir="${BACKUPDIR}/hot/$(date +%Y%m%d%H%M).etcd"
 mkdir -p $hotdir
 
+. /etc/etcd/etcd.conf
+
 echo "backuping the data directory to $hotdir"
-$ETCD backup --data-dir $etcd_storage --backup-dir $hotdir
+etcdctl backup --data-dir ${ETCD_DATA_DIR} --backup-dir $hotdir
 echo
 du -ksh $hotdir
 find $hotdir

--- a/backup/etcd/get_env.py
+++ b/backup/etcd/get_env.py
@@ -17,12 +17,15 @@ with open(os.path.join(basedir, 'master-config.yaml'), 'r') as stream:
     print('export etcd_certFile=' + os.path.join(basedir, clientconf['certFile']))
     print('export etcd_keyFile=' + os.path.join(basedir, clientconf['keyFile']))
     print('export etcd_url=' + ','.join(clientconf['urls']))
+    stor = None
     try:
         stor = conf['etcdConfig']['storageDirectory']
     except:
-        for line in open('/etc/etcd/etcd.conf', 'r'):
-            if re.search('ETCD_DATA_DIR', line):
-                stor = line.replace('ETCD_DATA_DIR=', '').rstrip('\n/')
-                print('export etcd_outside_openshift=yes')
-                break
+        etcdconf = '/etc/etcd/etcd.conf'
+        if os.path.isfile(etcdconf):
+            for line in open(etcdconf, 'r'):
+                if re.search('ETCD_DATA_DIR', line):
+                    stor = line.replace('ETCD_DATA_DIR=', '').rstrip('\n/')
+                    print('export etcd_outside_openshift=yes')
+                    break
     print('export etcd_storage=%s' % stor)


### PR DESCRIPTION
Also simplify backup script: backup mode is local and
does not require remote connection so args like cert-file,
ca-file etc are not required.

issue #1
