### PR TITLE
make backups work on etcd 3.x

### DIFF
--- a/backup/etcd/backup_etcd.sh
+++ b/backup/etcd/backup_etcd.sh
@@ -11,6 +11,9 @@ mkdir -p $hotdir
 
 echo "backuping the data directory to $hotdir"
 etcdctl backup --data-dir ${ETCD_DATA_DIR} --backup-dir $hotdir
+if [[ -e ${ETCD_DATA_DIR}/member/snap/db ]]; then
+    cp -a ${ETCD_DATA_DIR}/member/snap/db ${hotdir}/member/snap/
+fi
 echo
 du -ksh $hotdir
 find $hotdir


### PR DESCRIPTION
etcd 3.x needs `member/snap/db` backed up in order for a restore to work. Refer
to https://github.com/coreos/etcd/blob/master/Documentation/op-guide/recovery.md

"""A snapshot may either be taken from a live member with the etcdctl snapshot
save command or by copying the member/snap/db file from an etcd data
directory."""